### PR TITLE
pom fix: перемещение библиотеки в bin-repo из deploy в build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                   <type>${project.packaging}</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>
-                    ${env.BIN_HOME}/deploy/org/jepria/${project.artifactId}/${project.version}
+                    ${env.BIN_HOME}/build/org/jepria/${project.artifactId}/${project.version}
                   </outputDirectory>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
Отредактирован pom.xml: перенос библиотеки в bin-repo из deploy в build.
